### PR TITLE
Add persistent grade display

### DIFF
--- a/OgrenciOdevYonetimSistemi/Controllers/OgrenciController.cs
+++ b/OgrenciOdevYonetimSistemi/Controllers/OgrenciController.cs
@@ -66,6 +66,9 @@ namespace OgrenciOdevYonetimSistemi.Controllers
                                  .FirstOrDefault(n => n.OgrenciId == ogrenci.OgrenciId);
 
             double? ortalama = null;
+            string basariDurumu = "Not girişi sağlanmadı";
+            string renk = "secondary";
+
             if (notlar != null)
             {
                 var notList = new List<int?> { notlar.Vize, notlar.Final, notlar.Proje }
@@ -73,17 +76,18 @@ namespace OgrenciOdevYonetimSistemi.Controllers
                                 .Select(n => n.Value);
 
                 if (notList.Any())
+                {
                     ortalama = Math.Round(notList.Average(), 2);
+
+                    basariDurumu = "Yetersiz";
+                    renk = "danger";
+                    if (ortalama >= 85) { basariDurumu = "Pekiyi"; renk = "success"; }
+                    else if (ortalama >= 70) { basariDurumu = "İyi"; renk = "info"; }
+                    else if (ortalama >= 50) { basariDurumu = "Orta"; renk = "warning"; }
+                }
             }
 
             ViewBag.Ortalama = ortalama;
-
-            string basariDurumu = "Yetersiz";
-            string renk = "danger";
-
-            if (ortalama >= 85) { basariDurumu = "Pekiyi"; renk = "success"; }
-            else if (ortalama >= 70) { basariDurumu = "İyi"; renk = "info"; }
-            else if (ortalama >= 50) { basariDurumu = "Orta"; renk = "warning"; }
 
             ViewBag.BasariDurumu = basariDurumu;
             ViewBag.Renk = renk;

--- a/OgrenciOdevYonetimSistemi/Controllers/OgretmenController.cs
+++ b/OgrenciOdevYonetimSistemi/Controllers/OgretmenController.cs
@@ -200,12 +200,22 @@ namespace OgrenciOdevYonetimSistemi.Controllers
         [HttpGet]
         public IActionResult NotGir()
         {
-            var ogrenciler = _context.Ogrenciler.Select(o => new NotGirViewModel
-            {
-                OgrenciId = o.OgrenciId,
-                AdSoyad = o.AdSoyad
-            }).ToList();
+            var ogrenciler = _context.Ogrenciler
+                .GroupJoin(_context.OgrenciNotlari,
+                    o => o.OgrenciId,
+                    n => n.OgrenciId,
+                    (o, notlar) => new { Ogrenci = o, Not = notlar.FirstOrDefault() })
+                .Select(x => new NotGirViewModel
+                {
+                    OgrenciId = x.Ogrenci.OgrenciId,
+                    AdSoyad = x.Ogrenci.AdSoyad,
+                    Vize = x.Not?.Vize,
+                    Final = x.Not?.Final,
+                    Proje = x.Not?.Proje
+                })
+                .ToList();
 
+            ViewBag.Basarili = TempData["Basarili"];
             return View(ogrenciler);
         }
 
@@ -234,8 +244,8 @@ namespace OgrenciOdevYonetimSistemi.Controllers
             } 
 
             _context.SaveChanges();
-            ViewBag.Basarili = "Notlar başarıyla kaydedildi.";
-            return RedirectToAction("Panel");
+            TempData["Basarili"] = "Notlar başarıyla kaydedildi.";
+            return RedirectToAction("NotGir");
         }
 
         [HttpGet]

--- a/OgrenciOdevYonetimSistemi/Views/Ogrenci/Notlarim.cshtml
+++ b/OgrenciOdevYonetimSistemi/Views/Ogrenci/Notlarim.cshtml
@@ -43,7 +43,7 @@
     else
     {
         <div class="alert alert-warning text-center mt-4 fw-semibold">
-            Henüz not girilmemiş.
+            Not girişi sağlanmadı.
         </div>
     }
 </div>

--- a/OgrenciOdevYonetimSistemi/Views/Ogretmen/NotGir.cshtml
+++ b/OgrenciOdevYonetimSistemi/Views/Ogretmen/NotGir.cshtml
@@ -8,6 +8,11 @@
 <div class="container mt-5">
     <h2 class="text-center fw-bold text-primary mb-4">📋 Öğrencilere Not Gir</h2>
 
+    @if (ViewBag.Basarili != null)
+    {
+        <div class="alert alert-success text-center">@ViewBag.Basarili</div>
+    }
+
     <form asp-action="NotGir" method="post">
         <div class="table-responsive">
             <table class="table table-bordered table-hover text-center">

--- a/OgrenciOdevYonetimSistemi/Views/Ogretmen/Panel.cshtml
+++ b/OgrenciOdevYonetimSistemi/Views/Ogretmen/Panel.cshtml
@@ -50,6 +50,18 @@
             </div>
         </div>
 
+        <!-- 📝 Not Gir -->
+        <div class="col">
+            <div class="card shadow-sm border-0 h-100">
+                <div class="card-body text-center">
+                    <i class="bi bi-pencil-square fs-1 text-primary"></i>
+                    <h5 class="card-title mt-2">Not Gir</h5>
+                    <p class="card-text">Öğrencilerin sınav veya proje notlarını sisteme kaydedin.</p>
+                    <a class="btn btn-outline-primary btn-sm" asp-controller="Ogretmen" asp-action="NotGir">Git</a>
+                </div>
+            </div>
+        </div>
+
         <!-- 📚 Verilen Ödevler -->
         <div class="col">
             <div class="card shadow-sm border-0 h-100">


### PR DESCRIPTION
## Summary
- keep previously entered grades visible when revisiting `NotGir`
- redirect back to grade entry after saving so teachers see saved data
- show success message on the grade entry page
- display "Not girişi sağlanmadı" for students when no grades exist

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d92dc8740832e9ebb24b96cbd6272